### PR TITLE
add support for multiple leader characters

### DIFF
--- a/bot/line.py
+++ b/bot/line.py
@@ -43,7 +43,7 @@ class Line:
                 if p[0] == ':':
                     message = True
                     try:
-                        if p[1] == leader:
+                        if p[1] in leader:
                             self.command = p.strip()[2:]
                         else:
                             txt.append(p.strip()[1:])


### PR DESCRIPTION
After this change, one or more leader characters may be configured by simply setting in the config yaml:

```
settings:
  leader: "!.,;=:"
```

A single leader will also continue to work unchanged:

```
settings:
  leader: "!"
```